### PR TITLE
Add Partner ETL DAGs [Resolves #4]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ output/*
 
 # missed test log
 missed.txt
+
+dags/private/*

--- a/README.md
+++ b/README.md
@@ -27,8 +27,25 @@ output_folder: # a relative local directory for outputting tabular data
 normalizer:
     es_index_name: # name of desired elasticsearch normalizer index name
     titles_master_index_name: # name of desired job title index name
+raw_jobs_s3_paths:
+    XX: 'some-bucket/jobs/dump/' # key is partner code, value is s3 path to partner's s3 path
+airflow_contacts: # a list of email addresses to send errors to
+    - myemail@email.com
 ```
 
 - For the elasticsearch indexing tasks to work, you will also need to define the `ELASTICSEARCH_ENDPOINT` environment variable to an elasticsearch 5.0 endpoint, and the `PYTHONPATH` environment variable (should set to '.').
 
 - Run scheduler: `airflow scheduler`
+
+
+## Adding private job listing data sources
+
+The PartnerETL DAG is designed to mix job listings from private sources and public sources without adding any private-source specific code into this public repository. If you'd like to add ETL for a private data source, follow these steps:
+
+- Subclass JobPostingImportBase from the skills_utils public repository; this involves implementing an `_iter_postings` to define business logic to iterate through available postings for a given quarter, a `_transform` method to transform a given posting into the common schema, and an `_id` method to define a source-unique id for a given posting. Reference: https://github.com/workforce-data-initiative/skills-utils/blob/master/skills_utils/job_posting_import.py
+
+- Make this available in an __init__.py. Give the source a unique prefix, and define an `importers` dict in the __init__.py that points to the JobPostingImportBase subclass. (ie `importers = {'CB': CareerBuilderTransformer}`. Puts this __init__.py in `dags/private`. This path is ignored by git and will be imported only if present.
+
+- Add any s3 paths to your config.yaml's `raw_jobs_s3_paths` dictionary, keyed on the prefix you chose.
+
+The PartnerETL DAG will instantiate an operator for all private data sources and run the quarterly ETL tasks.

--- a/dags/partner_update.py
+++ b/dags/partner_update.py
@@ -1,0 +1,39 @@
+from airflow import DAG
+from operators.partner_update import PartnerUpdateOperator
+from datetime import datetime
+from config import config
+
+from skills_utils.s3 import split_s3_path
+
+default_args = {
+    'depends_on_past': False,
+    'start_date': datetime(2010, 1, 1),
+}
+
+
+def define_partner_update(main_dag_name):
+    dag = DAG(
+        dag_id='{}.partner_update'.format(main_dag_name),
+        default_args=default_args,
+        schedule_interval='@once'
+    )
+
+    raw_jobs = config.get('raw_jobs_s3_paths', {})
+    if not raw_jobs:
+        return dag
+    va_bucket, va_prefix = split_s3_path(raw_jobs['VA'])
+    PartnerUpdateOperator(
+        task_id='va_jobs_update',
+        dag=dag,
+        sources=[
+            'http://opendata.cs.vt.edu/dataset/2002e48d-363e-40d1-9d1b-a134301126a7/resource/d40efa75-ed86-4a01-9854-90d27539d477/download/joblistings.merged.parsed.unique.grpbyyear.2010-2015.01.json',
+            'http://opendata.cs.vt.edu/dataset/2002e48d-363e-40d1-9d1b-a134301126a7/resource/c7d4d3e6-61fb-4985-920d-7ac20732083d/download/joblistings.merged.parsed.unique.grpbyyear.2010-2015.02.json',
+            'http://opendata.cs.vt.edu/dataset/2002e48d-363e-40d1-9d1b-a134301126a7/resource/638255b0-cd2f-4b34-8abb-cf46f075bdfd/download/joblistings.merged.parsed.unique.grpbyyear.2010-2015.03.json',
+            'http://opendata.cs.vt.edu/dataset/2002e48d-363e-40d1-9d1b-a134301126a7/resource/7e14bb60-2474-420b-ae7b-62b195051f1f/download/joblistings.merged.parsed.unique.grpbyyear.2010-2015.04.json',
+            'http://opendata.cs.vt.edu/dataset/b67a5b8e-679a-4442-a8c8-4bb55a4618d6/resource/62da570a-6970-46de-b206-dab067ba51eb/download/joblistings.merged.parsed.unique.grpbyyear.2016.json'],
+        output_bucket=va_bucket,
+        output_prefix=va_prefix,
+        cache_headers=['Content-Range'],
+    )
+
+    return dag

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -10,4 +10,8 @@ output_tables:
     s3_path: 'output-bucket/tables'
 local_mode: True
 output_folder: 'output'
+raw_jobs_s3_paths:
+    XX: 'some-bucket/jobs/dump/'
+airflow_contacts:
+    - datascifellows@gmail.com
 ...

--- a/operators/partner_etl.py
+++ b/operators/partner_etl.py
@@ -1,0 +1,81 @@
+from airflow.models import BaseOperator
+from airflow.hooks import S3Hook
+from airflow.utils.decorators import apply_defaults
+from skills_ml.datasets.onet_cache import OnetCache
+from skills_utils.iteration import Batch
+from skills_utils.time import datetime_to_quarter
+import tempfile
+import boto
+import uuid
+import json
+import logging
+from config import config
+
+
+class PartnerETLOperator(BaseOperator):
+    @apply_defaults
+    def __init__(
+            self,
+            transformer_class,
+            output_bucket,
+            output_prefix,
+            partner_id,
+            passthrough_kwargs,
+            postings_per_file=10000,
+            *args, **kwargs):
+        super(PartnerETLOperator, self).__init__(*args, **kwargs)
+        self.transformer_class = transformer_class
+        self.output_bucket = output_bucket
+        self.output_prefix = output_prefix
+        self.partner_id = partner_id
+        self.postings_per_file = postings_per_file
+        self.passthrough_kwargs = passthrough_kwargs
+
+    def clear_old_postings(self, connection, quarter):
+        logging.info('Clearing out old postings')
+        bucket = connection.get_bucket(self.output_bucket)
+        partner_prefix = '{}/{}/{}_'.format(
+            self.output_prefix,
+            quarter,
+            self.partner_id
+        )
+        keylist = list(bucket.list(prefix=partner_prefix, delimiter=''))
+        logging.info('Found %s old postings', len(keylist))
+        for key in keylist:
+            key.delete()
+        logging.info('Done deleting postings')
+
+    def execute(self, context):
+        conn = S3Hook().get_conn()
+        transformer = self.transformer_class(
+            s3_conn=conn,
+            partner_id=self.partner_id,
+            onet_cache=OnetCache(
+                s3_conn=conn,
+                cache_dir=config['onet']['cache_dir'],
+                s3_path=config['onet']['s3_path'],
+            ),
+            **self.passthrough_kwargs
+        )
+        quarter = datetime_to_quarter(context['execution_date'])
+        self.clear_old_postings(conn, quarter)
+        for batch in Batch(
+            transformer.postings(quarter),
+            self.postings_per_file
+        ):
+            logging.info('Processing new batch')
+            with tempfile.TemporaryFile() as f:
+                for posting in batch:
+                    f.write(json.dumps(posting))
+                    f.write('\n')
+
+                logging.debug('New batch written, commencing upload')
+                bucket = conn.get_bucket(self.output_bucket)
+                key = boto.s3.key.Key(
+                    bucket=bucket,
+                    name='{}/{}/{}_{}'.format(self.output_prefix, quarter,
+                                              self.partner_id, uuid.uuid4())
+                )
+                f.seek(0)
+                key.set_contents_from_file(f)
+                logging.debug('Batch upload complete')

--- a/operators/partner_update.py
+++ b/operators/partner_update.py
@@ -1,0 +1,71 @@
+from airflow.models import BaseOperator
+from airflow.hooks import S3Hook
+from airflow.utils.decorators import apply_defaults
+from skills_utils.iteration import Batch
+import logging
+import tempfile
+import requests
+import boto
+import uuid
+import json
+
+
+class PartnerUpdateOperator(BaseOperator):
+    @apply_defaults
+    def __init__(
+            self,
+            sources,
+            output_bucket,
+            output_prefix,
+            cache_headers=['Date', 'Last-Modified'],
+            *args, **kwargs):
+        super(PartnerUpdateOperator, self).__init__(*args, **kwargs)
+        self.sources = sources
+        self.output_bucket = output_bucket
+        self.output_prefix = output_prefix
+        self.cache_headers = cache_headers
+        self.postings_per_file = 10000
+
+    def execute(self, context):
+        conn = S3Hook().get_conn()
+        bucket = conn.get_bucket(self.output_bucket)
+
+        for url in self.sources:
+            name = url.split('/')[-1]
+            r = requests.get(url, stream=True)
+
+            # Check the remote headers against the stored headers
+            cache_dict = {k: r.headers[k] for k in self.cache_headers}
+            cache_key = boto.s3.key.Key(
+                bucket=bucket,
+                name='{}/{}/.cache.json'.format(self.output_prefix, name)
+            )
+            if cache_key.exists():
+                logging.info("Checking %s for updates", name)
+                stored_cache = json.loads(cache_key.get_contents_as_string())
+                if cache_dict == stored_cache:
+                    logging.info("Skipping %s", name)
+                    continue
+            logging.info("Downloading %s", name)
+            # Cached headers differ; DELETE ALL EXISTING DATA
+            for key in bucket.list(
+                prefix="{}/{}/".format(self.output_prefix, name)
+            ):
+                key.delete()
+            cache_key.set_contents_from_string(json.dumps(cache_dict))
+
+            for batch in Batch(r.iter_lines(), self.postings_per_file):
+                key = boto.s3.key.Key(
+                    bucket=bucket,
+                    name='{}/{}/{}'.format(
+                        self.output_prefix,
+                        name,
+                        str(uuid.uuid4()) + ".json"
+                    )
+                )
+                with tempfile.TemporaryFile() as f:
+                    for posting in batch:
+                        f.write(posting)
+                        f.write('\n')
+                    f.seek(0)
+                    key.set_contents_from_file(f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 airflow[s3]<1.8
 
 git+git://github.com/workforce-data-initiative/skills-ml.git@master
+git+git://github.com/workforce-data-initiative/skills-utils.git@master

--- a/tests/api_sync_v1/test_dag.py
+++ b/tests/api_sync_v1/test_dag.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy import create_engine
 from airflow import models
 from mock import patch
-from dags.api_sync_v1 import define_api_sync
+from dags.open_skills_master import api_sync_dag
 from skills_ml.api_sync.v1.models import JobMaster,\
     SkillMaster,\
     SkillImportance,\
@@ -19,7 +19,7 @@ configuration.test_mode()
 
 
 def test_dag():
-    dag = define_api_sync('open_skills_master')
+    dag = api_sync_dag
     with testing.postgresql.Postgresql() as postgresql:
         configuration.test_mode()
 

--- a/tmp/README.md
+++ b/tmp/README.md
@@ -1,0 +1,1 @@
+This file exists to force the tmp/ directory to be created upon cloning the repo


### PR DESCRIPTION
- Fill out partner_etl DAG, include public data sources always, and private data sources if present in dags/private
- Add partner_update DAG to handle updating S3 cache from a data source
- Add partner_etl and partner_update operators
- Make sure tmp directory is there
- Update README, make airflow contacts optional
- Add OnetCache to PartnerETLOperator
- Allow factory functions to run to completion without config