### PR TITLE
Sync USAJobs Raw Data [Resolves #16]

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ normalizer:
     titles_master_index_name: # name of desired job title index name
 raw_jobs_s3_paths:
     XX: 'some-bucket/jobs/dump/' # key is partner code, value is s3 path to partner's s3 path
+usa_jobs_credentials: # if you want to sync USAJobs data, include your API key information
+    auth_key: 'akey'
+    key_email: 'anemail@email.com'
 airflow_contacts: # a list of email addresses to send errors to
     - myemail@email.com
 ```

--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -24,6 +24,9 @@ partner_stats:
     s3_path: 'stats-bucket/partner-etl'
 raw_jobs_s3_paths:
     XX: 'some-bucket/jobs/dump/'
+usa_jobs_credentials:
+    auth_key: 'akey'
+    key_email: 'anemail@email.com'
 airflow_contacts:
     - datascifellows@gmail.com
 ...

--- a/dags/open_skills_master.py
+++ b/dags/open_skills_master.py
@@ -5,7 +5,8 @@ from airflow import DAG
 from airflow.operators.subdag_operator import SubDagOperator
 from dags.api_sync_v1 import define_api_sync
 from dags.partner_etl import define_partner_etl
-from dags.partner_update import define_partner_update
+from dags.partner_quarterly import define_partner_quarterly
+from dags.partner_nightly import define_partner_nightly
 from dags.onet_extract import define_onet_extract
 from dags.elasticsearch_normalizer import define_normalizer_index
 from dags.title_count import define_title_counts
@@ -29,7 +30,8 @@ MAIN_DAG_NAME = 'open_skills_master'
 
 api_sync_dag = define_api_sync(MAIN_DAG_NAME)
 partner_etl_dag = define_partner_etl(MAIN_DAG_NAME)
-partner_update_dag = define_partner_update(MAIN_DAG_NAME)
+partner_quarterly_dag = define_partner_quarterly(MAIN_DAG_NAME)
+partner_nightly_dag = define_partner_nightly(MAIN_DAG_NAME)
 onet_extract_dag = define_onet_extract(MAIN_DAG_NAME)
 normalizer_index_dag = define_normalizer_index(MAIN_DAG_NAME)
 title_count_dag = define_title_counts(MAIN_DAG_NAME)
@@ -58,9 +60,15 @@ partner_etl = SubDagOperator(
     dag=dag,
 )
 
-partner_update = SubDagOperator(
-    subdag=partner_update_dag,
-    task_id='partner_update',
+partner_quarterly = SubDagOperator(
+    subdag=partner_quarterly_dag,
+    task_id='partner_quarterly',
+    dag=dag,
+)
+
+partner_nightly = SubDagOperator(
+    subdag=partner_nightly_dag,
+    task_id='partner_nightly',
     dag=dag,
 )
 
@@ -118,7 +126,8 @@ tabular_upload = SubDagOperator(
     dag=dag
 )
 
-partner_etl.set_upstream(partner_update)
+partner_etl.set_upstream(partner_quarterly)
+partner_etl.set_upstream(partner_nightly)
 api_sync.set_upstream(title_count)
 api_sync.set_upstream(onet_extract)
 api_sync.set_upstream(normalizer_index)

--- a/dags/partner_etl.py
+++ b/dags/partner_etl.py
@@ -12,6 +12,7 @@ from config import config
 from operators.partner_etl import PartnerETLOperator,\
     PartnerStatsAggregateOperator,\
     GlobalStatsAggregateOperator
+import logging
 from utils.dags import QuarterlySubDAG
 
 
@@ -25,7 +26,10 @@ def define_partner_etl(main_dag_name):
 
     partner_stats = {}
     for partner_id, s3_path in raw_jobs.items():
-        importer_class = importers[partner_id]
+        importer_class = importers.get(partner_id, None)
+        if not importer_class:
+            logging.warning('Importer for %s not found, skipping', partner_id)
+            continue
 
         input_bucket, input_prefix = split_s3_path(s3_path)
 

--- a/dags/partner_nightly.py
+++ b/dags/partner_nightly.py
@@ -1,0 +1,37 @@
+from airflow import DAG
+from operators.partner_snapshot import PartnerSnapshotOperator
+from datetime import datetime
+from config import config
+
+from skills_ml.datasets.partner_updaters import USAJobsUpdater
+
+
+default_args = {
+    'depends_on_past': False,
+    'start_date': datetime(2017, 5, 1),
+}
+
+
+def define_partner_nightly(main_dag_name):
+    dag = DAG(
+        dag_id='{}.partner_nightly'.format(main_dag_name),
+        default_args=default_args,
+        schedule_interval='@daily'
+    )
+
+    raw_jobs = config.get('raw_jobs_s3_paths', {})
+    if not raw_jobs:
+        return dag
+
+    usa_jobs_credentials = config.get('usa_jobs_credentials', {})
+    if not usa_jobs_credentials:
+        return dag
+    PartnerSnapshotOperator(
+        task_id='usa_jobs_update',
+        dag=dag,
+        s3_prefix=raw_jobs['US'],
+        updater_class=USAJobsUpdater,
+        passthrough_kwargs=usa_jobs_credentials
+    )
+
+    return dag

--- a/dags/partner_quarterly.py
+++ b/dags/partner_quarterly.py
@@ -11,11 +11,11 @@ default_args = {
 }
 
 
-def define_partner_update(main_dag_name):
+def define_partner_quarterly(main_dag_name):
     dag = DAG(
-        dag_id='{}.partner_update'.format(main_dag_name),
+        dag_id='{}.partner_quarterly'.format(main_dag_name),
         default_args=default_args,
-        schedule_interval='@once'
+        schedule_interval='0 0 1 */3 *',
     )
 
     raw_jobs = config.get('raw_jobs_s3_paths', {})

--- a/operators/partner_snapshot.py
+++ b/operators/partner_snapshot.py
@@ -1,0 +1,36 @@
+import logging
+from airflow.models import BaseOperator
+from airflow.hooks import S3Hook
+from airflow.utils.decorators import apply_defaults
+from skills_utils.s3 import upload_dict
+from skills_utils.time import datetime_to_quarter
+from datetime import datetime
+
+
+class PartnerSnapshotOperator(BaseOperator):
+    @apply_defaults
+    def __init__(
+            self,
+            updater_class,
+            passthrough_kwargs,
+            s3_prefix,
+            *args, **kwargs):
+        super(PartnerSnapshotOperator, self).__init__(*args, **kwargs)
+        self.updater_class = updater_class
+        self.passthrough_kwargs = passthrough_kwargs
+        self.s3_prefix = s3_prefix
+
+    def execute(self, context):
+        conn = S3Hook().get_conn()
+        execution_date = context['execution_date']
+        quarter = datetime_to_quarter(execution_date)
+        if quarter != datetime_to_quarter(datetime.now()):
+            logging.warning('PartnerSnapshotOperator cannot be backfilled. Skipping')
+            return
+        updater = self.updater_class(**(self.passthrough_kwargs))
+        postings = updater.deduplicated_postings()
+        upload_dict(
+            s3_conn=conn,
+            s3_prefix=self.s3_prefix + '/' + quarter,
+            data_to_sync=postings
+        )


### PR DESCRIPTION
- Rename PartnerUpdate to PartnerQuarterly
- Add PartnerSnapshotOperator for pulling point-in-time snapshots of data sources
- Add PartnerNightly for USAJobs sync
- Add USAJobs credential placeholders in example_config.yaml
- Add skipping in PartnerETL if there is no common schema transformer written for that partner yet