### PR TITLE
Call partner stats counter and aggregators [Resolves #19] (wip, adding test)

### DIFF
--- a/config/example_config.yaml
+++ b/config/example_config.yaml
@@ -14,6 +14,8 @@ output_tables:
     cleaned_title_count_dir: 'cleaned_title_count'
 local_mode: True
 output_folder: 'output'
+partner_stats:
+    s3_path: 'stats-bucket/partner-etl'
 raw_jobs_s3_paths:
     XX: 'some-bucket/jobs/dump/'
 airflow_contacts:

--- a/operators/partner_etl.py
+++ b/operators/partner_etl.py
@@ -107,7 +107,6 @@ class PartnerStatsAggregateOperator(BaseOperator):
 
 
 class GlobalStatsAggregateOperator(BaseOperator):
-    @apply_defaults
     def execute(self, context):
         conn = S3Hook().get_conn()
         stats_aggregator = GlobalStatsAggregator(s3_conn=conn)


### PR DESCRIPTION
(Don't merge this yet, adding a test, but I wanted to get this up there as I already uploaded the image)

- Add partner_stats s3 configuration section
- Pass in DatasetStatsCounter to all job posting importers and save at the end
- Create PartnerStatsAggregate and GlobalStatsAggregate operators to handle aggregation of dataset stats
- Add suffix to partner ETL task ids for disambiguation
- Add stats aggregation operators to Partner ETL DAG

![stats_dag](https://user-images.githubusercontent.com/1649545/26839976-453752b2-4aaa-11e7-97b3-7d06a85158c6.png)