### PR TITLE
Parallelizing fixes

### DIFF
--- a/dags/soc_count.py
+++ b/dags/soc_count.py
@@ -2,6 +2,10 @@
 title extraction, cleaning, and aggregation
 """
 from collections import OrderedDict
+from uuid import uuid4
+import logging
+import os
+import joblib
 
 from airflow.hooks import S3Hook
 
@@ -11,10 +15,24 @@ from skills_ml.algorithms.corpus_creators.basic import SimpleCorpusCreator
 from skills_ml.algorithms.occupation_classifiers.classifiers import Classifier
 
 from utils.dags import QuarterlySubDAG
-from operators.geo_count import GeoCountOperator
+from operators.geo_count import GeoCountOperator, MergeOperator
 
 
-def soc_aggregate(job_postings, aggregator_constructor, classifier_id, classify_kwargs):
+def save(aggregator, temp_dir):
+    pickle_filename = os.path.join(temp_dir, str(uuid4()) + '.pkl')
+    logging.info('Pickling to %s', pickle_filename)
+    joblib.dump(aggregator, pickle_filename)
+    logging.info('Done pickling to %s', pickle_filename)
+    return pickle_filename
+
+
+def soc_aggregate(
+    job_postings,
+    aggregator_constructor,
+    temp_dir,
+    classifier_id,
+    classify_kwargs
+):
     s3_conn = S3Hook().get_conn()
     corpus_creator = SimpleCorpusCreator()
     count_aggregator = CountAggregator()
@@ -24,6 +42,7 @@ def soc_aggregate(job_postings, aggregator_constructor, classifier_id, classify_
         classifier = Classifier(
             classifier_id=classifier_id,
             classify_kwargs=classify_kwargs,
+            temporary_directory=temp_dir,
             s3_conn=s3_conn
         )
     aggregator = aggregator_constructor(
@@ -32,13 +51,19 @@ def soc_aggregate(job_postings, aggregator_constructor, classifier_id, classify_
         job_aggregators=job_aggregators,
     )
     aggregator.process_postings(job_postings)
-    return aggregator.job_aggregators
+    aggregator.occupation_classifier = None
+    return save(aggregator, temp_dir)
 
 
 def define_soc_counts(main_dag_name):
     dag = QuarterlySubDAG(main_dag_name, 'soc_count')
 
     class GeoSOCCountOperator(GeoCountOperator):
+        def __init__(self, *args, **kwargs):
+            kwargs['map_function'] = soc_aggregate
+            kwargs['func_name'] = 'count'
+            super(GeoSOCCountOperator, self).__init__(*args, **kwargs)
+
         def aggregator_constructor(self):
             return GeoSocAggregator
 
@@ -48,27 +73,44 @@ def define_soc_counts(main_dag_name):
                 'classify_kwargs': self.classify_kwargs
             }
 
-        map_function = soc_aggregate
-
     class GeoSOCCommonCountOperator(GeoSOCCountOperator):
+        prefix = 'common'
         group_config_key = 'geo_soc_common_count_dir'
         rollup_config_key = 'soc_common_count_dir'
         classifier_id = 'ann_0614'
         classify_kwargs = {'mode': 'common'}
 
     class GeoSOCTopCountOperator(GeoSOCCountOperator):
+        prefix = 'top'
         group_config_key = 'geo_soc_top_count_dir'
         rollup_config_key = 'soc_top_count_dir'
         classifier_id = 'ann_0614'
         classify_kwargs = {'mode': 'top'}
 
     class GeoSOCGivenCountOperator(GeoSOCCountOperator):
+        prefix = 'given'
         group_config_key = 'geo_soc_given_count_dir'
         rollup_config_key = 'soc_given_count_dir'
         classifier_id = None
+        classify_kwargs = {}
 
-    GeoSOCCommonCountOperator(task_id='geo_soc_common_count', dag=dag)
-    GeoSOCTopCountOperator(task_id='geo_soc_top_count', dag=dag)
-    GeoSOCGivenCountOperator(task_id='geo_soc_given_count', dag=dag)
+    for operator in [
+        GeoSOCCommonCountOperator,
+        GeoSOCTopCountOperator,
+        GeoSOCGivenCountOperator
+    ]:
+        count = operator(
+            task_id='geo_soc_{}_count'.format(operator.prefix),
+            func_name='count',
+            dag=dag
+        )
+
+        merge = MergeOperator(
+            task_id='{}_merge'.format(operator.prefix),
+            group_config_key=operator.group_config_key,
+            rollup_config_key=operator.rollup_config_key,
+            dag=dag
+        )
+        merge.set_upstream(count)
 
     return dag

--- a/dags/title_count.py
+++ b/dags/title_count.py
@@ -1,8 +1,8 @@
+
 """Takes common schema job listings and performs
 title extraction, cleaning, and aggregation
 """
 import os
-from collections import OrderedDict
 
 from airflow.hooks import S3Hook
 from skills_ml.algorithms.aggregators import\
@@ -13,83 +13,200 @@ from skills_ml.algorithms.jobtitle_cleaner.clean import JobTitleStringClean
 from skills_ml.algorithms.string_cleaners import NLPTransforms
 from skills_ml.algorithms.skill_extractors.freetext\
     import FreetextSkillExtractor
-from skills_ml.algorithms.occupation_classifiers.classifiers import Classifier, download_ann_classifier_files
+from skills_ml.algorithms.occupation_classifiers.classifiers import \
+    Classifier, download_ann_classifier_files
 from skills_utils.s3 import download
 
 from config import config
-from operators.geo_count import GeoCountOperator
+from operators.geo_count import GeoCountOperator, MergeOperator
 from utils.dags import QuarterlySubDAG
+from uuid import uuid4
+from functools import partial
+import logging
+import joblib
 
 
-def title_aggregate(
-        job_postings,
-        aggregator_constructor,
-        processed_folder,
-        phase_indices,
-        download_folder,
+def save(aggregator, temp_dir):
+    pickle_filename = os.path.join(temp_dir, str(uuid4()) + '.pkl')
+    logging.info('Pickling to %s', pickle_filename)
+    joblib.dump(aggregator, pickle_filename, protocol=4)
+    logging.info('Done pickling to %s', pickle_filename)
+    return pickle_filename
+
+PHASE_FUNCTIONS = [
+    NLPTransforms().title_phase_one,
+    JobTitleStringClean().clean_title
+]
+
+
+def title_clean(title, phase_indices):
+    for phase_index in phase_indices:
+        title = PHASE_FUNCTIONS[phase_index](title)
+    return title
+
+
+def skill_aggregate(
+    job_postings,
+    aggregator_constructor,
+    temp_dir,
+    processed_folder,
+    phase_indices,
+    download_folder
 ):
-    nlp_transforms = NLPTransforms()
-    string_clean = JobTitleStringClean()
-    phase_functions = [nlp_transforms.title_phase_one, string_clean.clean_title]
+    title_cleaner = partial(title_clean, phase_indices=phase_indices)
 
-    def title_cleaner(title):
-        for phase_index in phase_indices:
-            title = phase_functions[phase_index](title)
-        return title
     skills_filename = '{}/skills_master_table.tsv'\
         .format(processed_folder)
 
-    download(
-        s3_conn=S3Hook().get_conn(),
-        out_filename=skills_filename,
-        s3_path=config['output_tables']['s3_path'] + '/skills_master_table.tsv'
+    if not os.path.isfile(skills_filename):
+        download(
+            s3_conn=S3Hook().get_conn(),
+            out_filename=skills_filename,
+            s3_path=config['output_tables']['s3_path'] + '/skills_master_table.tsv'
+        )
+    corpus_creator = SimpleCorpusCreator()
+    job_aggregators = {'onet_skills': SkillAggregator(
+        corpus_creator=corpus_creator,
+        skill_extractor=FreetextSkillExtractor(
+            skills_filename=skills_filename
+        ),
+        output_count=10
+    )}
+    aggregator = aggregator_constructor(
+        job_aggregators=job_aggregators,
+        title_cleaner=title_cleaner
     )
+    aggregator.process_postings(job_postings)
+    aggregator.job_aggregators['onet_skills'].skill_extractor = None
+    aggregator.job_aggregators['onet_skills'].corpus_creator = None
+    return save(
+        aggregator,
+        temp_dir,
+    )
+
+
+def classify_common(
+    job_postings,
+    aggregator_constructor,
+    temp_dir,
+    processed_folder,
+    phase_indices,
+    download_folder
+):
     s3_conn = S3Hook().get_conn()
     corpus_creator = SimpleCorpusCreator()
+    title_cleaner = partial(title_clean, phase_indices=phase_indices)
+
     common_classifier = Classifier(
         s3_conn=s3_conn,
         classifier_id='ann_0614',
         classify_kwargs={'mode': 'common'},
         temporary_directory=download_folder,
     )
-    top_classifier = Classifier(
-        s3_conn=s3_conn,
-        classifier=common_classifier.classifier,
-        classifier_id='ann_0614',
-        classify_kwargs={'mode': 'top'},
-        temporary_directory=download_folder,
-    )
-    job_aggregators = OrderedDict()
-    job_aggregators['counts'] = CountAggregator()
-    job_aggregators['onet_skills'] = SkillAggregator(
-        corpus_creator=corpus_creator,
-        skill_extractor=FreetextSkillExtractor(
-            skills_filename=skills_filename
-        ),
-        output_count=10
-    )
-    job_aggregators['soc_code_common'] = SocCodeAggregator(
+    job_aggregators = {'soc_code_common': SocCodeAggregator(
         corpus_creator=corpus_creator,
         occupation_classifier=common_classifier,
         output_count=2,
         output_total=True
+    )}
+
+    aggregator = aggregator_constructor(
+        job_aggregators=job_aggregators,
+        title_cleaner=title_cleaner
     )
-    job_aggregators['soc_code_top'] = SocCodeAggregator(
+
+    aggregator.process_postings(job_postings)
+    aggregator.job_aggregators['soc_code_common'].occupation_classifier = None
+    aggregator.job_aggregators['soc_code_common'].corpus_creator = None
+    return save(
+        aggregator,
+        temp_dir,
+    )
+
+
+def classify_top(
+    job_postings,
+    aggregator_constructor,
+    temp_dir,
+    processed_folder,
+    phase_indices,
+    download_folder
+):
+    s3_conn = S3Hook().get_conn()
+    corpus_creator = SimpleCorpusCreator()
+
+    title_cleaner = partial(title_clean, phase_indices=phase_indices)
+
+    top_classifier = Classifier(
+        s3_conn=s3_conn,
+        classifier_id='ann_0614',
+        classify_kwargs={'mode': 'top'},
+        temporary_directory=download_folder,
+    )
+    job_aggregators = {'soc_code_top': SocCodeAggregator(
         corpus_creator=corpus_creator,
         occupation_classifier=top_classifier,
         output_count=2,
         output_total=True
-    )
-    job_aggregators['soc_code_given'] = GivenSocCodeAggregator(
-        output_count=2,
-        output_total=True
-    )
+    )}
     aggregator = aggregator_constructor(
         job_aggregators=job_aggregators,
         title_cleaner=title_cleaner
     )
     aggregator.process_postings(job_postings)
-    return aggregator.job_aggregators
+    aggregator.job_aggregators['soc_code_top'].occupation_classifier = None
+    aggregator.job_aggregators['soc_code_top'].corpus_creator = None
+    return save(
+        aggregator,
+        temp_dir,
+    )
+
+
+def given_soc_code(
+    job_postings,
+    aggregator_constructor,
+    temp_dir,
+    processed_folder,
+    phase_indices,
+    download_folder
+):
+    title_cleaner = partial(title_clean, phase_indices=phase_indices)
+
+    job_aggregators = {'soc_code_given': GivenSocCodeAggregator(
+        output_count=2,
+        output_total=True
+    )}
+    aggregator = aggregator_constructor(
+        job_aggregators=job_aggregators,
+        title_cleaner=title_cleaner
+    )
+    aggregator.process_postings(job_postings)
+    return save(
+        aggregator,
+        temp_dir,
+    )
+
+
+def count_aggregate(
+    job_postings,
+    aggregator_constructor,
+    temp_dir,
+    processed_folder,
+    phase_indices,
+    download_folder
+):
+    title_cleaner = partial(title_clean, phase_indices=phase_indices)
+    job_aggregators = {'counts': CountAggregator()}
+    aggregator = aggregator_constructor(
+        job_aggregators=job_aggregators,
+        title_cleaner=title_cleaner
+    )
+    aggregator.process_postings(job_postings)
+    return save(
+        aggregator,
+        temp_dir,
+        job_postings
+    )
 
 
 def define_title_counts(main_dag_name):
@@ -100,8 +217,6 @@ def define_title_counts(main_dag_name):
     cache_s3_path = model_cache_config.get('s3_path', '')
 
     class GeoTitleCountOperator(GeoCountOperator):
-        map_function = title_aggregate
-
         def aggregator_constructor(self):
             return GeoTitleAggregator
 
@@ -128,13 +243,59 @@ def define_title_counts(main_dag_name):
         group_config_key = 'geo_title_count_dir'
         rollup_config_key = 'title_count_dir'
         phase_indices = [0]
+        prefix = 'phase_one'
 
     class GeoTitlePhaseTwoCountOperator(GeoTitleCountOperator):
         group_config_key = 'cleaned_geo_title_count_dir'
         rollup_config_key = 'cleaned_title_count_dir'
         phase_indices = [0, 1]
+        prefix = 'phase_two'
 
-    GeoTitlePhaseOneCountOperator(task_id='clean_phase_one_geo_count', dag=dag)
-    GeoTitlePhaseTwoCountOperator(task_id='clean_phase_two_geo_count', dag=dag)
+    for operator in [
+        GeoTitlePhaseOneCountOperator,
+        GeoTitlePhaseTwoCountOperator
+    ]:
+        skill = operator(
+            task_id='{}_skill'.format(operator.prefix),
+            map_function=skill_aggregate,
+            func_name='skills',
+            dag=dag
+        )
+        common = operator(
+            task_id='{}_common_soc'.format(operator.prefix),
+            map_function=classify_common,
+            func_name='common_soc',
+            dag=dag
+        )
+        top = operator(
+            task_id='{}_top_soc'.format(operator.prefix),
+            map_function=classify_top,
+            func_name='top_soc',
+            dag=dag
+        )
+        given = operator(
+            task_id='{}_given_soc'.format(operator.prefix),
+            map_function=given_soc_code,
+            func_name='given_soc',
+            dag=dag
+        )
+        count = operator(
+            task_id='{}_count'.format(operator.prefix),
+            map_function=count_aggregate,
+            func_name='count',
+            dag=dag
+        )
+
+        merge = MergeOperator(
+            task_id='{}_merge'.format(operator.prefix),
+            group_config_key=operator.group_config_key,
+            rollup_config_key=operator.rollup_config_key,
+            dag=dag
+        )
+        merge.set_upstream(skill)
+        merge.set_upstream(common)
+        merge.set_upstream(top)
+        merge.set_upstream(given)
+        merge.set_upstream(count)
 
     return dag

--- a/operators/geo_count.py
+++ b/operators/geo_count.py
@@ -2,6 +2,7 @@ import logging
 import os
 from functools import partial
 from multiprocessing import Pool
+import tempfile
 
 from airflow.hooks import S3Hook
 from airflow.operators import BaseOperator
@@ -9,17 +10,29 @@ from airflow.operators import BaseOperator
 from skills_ml.datasets.job_postings import job_postings_highmem
 from skills_utils.time import datetime_to_quarter
 from skills_utils.iteration import Batch
-from skills_utils.s3 import upload
+from skills_utils.s3 import upload, split_s3_path
+import pandas
 
 from config import config
+import joblib
 
 
 class GeoCountOperator(BaseOperator):
-    def map(self, pool, job_postings_generator):
+    def __init__(self, *args, **kwargs):
+        if 'map_function' in kwargs:
+            self.map_function = kwargs.pop('map_function')
+
+        if 'func_name' in kwargs:
+            self.func_name = kwargs.pop('func_name')
+
+        super(GeoCountOperator, self).__init__(*args, **kwargs)
+
+    def map(self, pool, job_postings_generator, temp_dir):
         passthroughs = self.passthroughs()
         bound_mapping_function = partial(
-            self.map_function.__func__,
+            self.map_function,
             aggregator_constructor=self.aggregator_constructor(),
+            temp_dir=temp_dir,
             **passthroughs
         )
         batched_dataset = (
@@ -32,13 +45,14 @@ class GeoCountOperator(BaseOperator):
         logging.info('Processing batched dataset')
         return pool.imap_unordered(bound_mapping_function, batched_dataset)
 
-    def reduce(self, aggregators):
-        combined_aggregator = self.aggregator_constructor()(
-            job_aggregators=next(aggregators)
-        )
-        for aggregator in aggregators:
-            combined_aggregator.merge_job_aggregators(aggregator)
-        return combined_aggregator
+    def reduce(self, pickle_filenames):
+        first_pickle_filename = next(pickle_filenames)
+        aggregator_obj = joblib.load(first_pickle_filename)
+
+        for pickle_filename in pickle_filenames:
+            logging.info('Merging aggregations from %s', pickle_filename)
+            aggregator_obj.merge_job_aggregators(joblib.load(pickle_filename).job_aggregators)
+        return aggregator_obj
 
     def output_folder(self):
         output_folder = config.get('output_folder', 'output')
@@ -47,25 +61,37 @@ class GeoCountOperator(BaseOperator):
         return output_folder
 
     def save(self, combined_aggregator, quarter, s3_conn):
-        count_filename = '{}/{}/{}.csv'.format(
+        logging.info('Saving group counts and rollup')
+        count_folder = '{}/{}'.format(
             self.output_folder(),
-            config['output_tables'][self.group_config_key],
-            quarter
+            config['output_tables'][self.group_config_key]
         )
-        rollup_filename = '{}/{}/{}.csv'.format(
+        if not os.path.isdir(count_folder):
+            os.makedirs(count_folder)
+
+        count_filename = '{}/{}_{}.csv'.format(
+            count_folder,
+            quarter,
+            self.func_name
+        )
+
+        rollup_folder = '{}/{}'.format(
             self.output_folder(),
             config['output_tables'][self.rollup_config_key],
-            quarter
+        )
+
+        if not os.path.isdir(rollup_folder):
+            os.makedirs(rollup_folder)
+
+        rollup_filename = '{}/{}_{}.csv'.format(
+            rollup_folder,
+            quarter,
+            self.func_name
         )
         combined_aggregator.save_counts(count_filename)
         combined_aggregator.save_rollup(rollup_filename)
 
-        logging.info(
-            'Found %s count rows and %s rollup rows for %s',
-            len(combined_aggregator.job_aggregators['counts'].group_values.keys()),
-            len(combined_aggregator.job_aggregators['counts'].rollup.keys()),
-            quarter,
-        )
+        logging.info('Uploading to s3')
         upload(
             s3_conn,
             count_filename,
@@ -87,14 +113,73 @@ class GeoCountOperator(BaseOperator):
         s3_conn = S3Hook().get_conn()
         quarter = datetime_to_quarter(context['execution_date'])
 
-        job_postings_generator = job_postings_highmem(
-            s3_conn,
-            quarter,
-            config['job_postings']['s3_path']
-        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            job_postings_generator = job_postings_highmem(
+                s3_conn,
+                quarter,
+                config['job_postings']['s3_path']
+            )
 
-        pool = Pool(processes=config['aggregation']['n_processes'])
-        combined_aggregator = self.reduce(
-            self.map(pool, job_postings_generator)
+            logging.basicConfig(
+                format='%(asctime)s %(process)d %(levelname)s: %(message)s'
+            )
+            with Pool(processes=config['aggregation']['n_processes']) as pool:
+                it = self.map(pool, job_postings_generator, temp_dir)
+                combined_agg = self.reduce(it)
+            self.save(combined_agg, quarter, s3_conn)
+
+
+def download_with_prefix(s3_conn, s3_prefix, out_directory):
+    bucket_name, prefix = split_s3_path(s3_prefix)
+    bucket = s3_conn.get_bucket(bucket_name)
+    out_filenames = []
+    for key in bucket.list(prefix=prefix):
+        leaf_name = key.name.split('/')[-1]
+        out_filename = os.path.join(out_directory, leaf_name)
+        key.get_contents_to_filename(out_filename)
+        out_filenames.append(out_filename)
+    return out_filenames
+
+
+def merge(s3_conn, config_key, quarter, output_folder):
+    prefix = '{}{}/{}'.format(
+        config['output_tables']['s3_path'],
+        config['output_tables'][config_key],
+        quarter
+    )
+    files = download_with_prefix(s3_conn, prefix + '_', output_folder)
+    merge_df = pandas.read_csv(files[0])
+    for other_file in files[1:]:
+        merge_df = merge_df.merge(pandas.read_csv(other_file))
+    merged_filename = os.path.join(output_folder, quarter + '.csv')
+    merge_df.to_csv(merged_filename, index=False)
+
+    upload(
+        s3_conn,
+        merged_filename,
+        '{}/{}'.format(
+            config['output_tables']['s3_path'],
+            config['output_tables'][config_key]
         )
-        self.save(combined_aggregator, quarter, s3_conn)
+    )
+
+
+class MergeOperator(BaseOperator):
+    def __init__(self, *args, **kwargs):
+        if 'group_config_key' in kwargs:
+            self.group_config_key = kwargs.pop('group_config_key')
+
+        if 'rollup_config_key' in kwargs:
+            self.rollup_config_key = kwargs.pop('rollup_config_key')
+
+        super(MergeOperator, self).__init__(*args, **kwargs)
+
+    def execute(self, context):
+        s3_conn = S3Hook().get_conn()
+        quarter = datetime_to_quarter(context['execution_date'])
+        output_folder = config.get('output_folder', 'output')
+        if not os.path.isdir(output_folder):
+            os.mkdir(output_folder)
+
+        merge(s3_conn, self.group_config_key, quarter, output_folder)
+        merge(s3_conn, self.rollup_config_key, quarter, output_folder)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 airflow[s3]<1.8
 alembic
+joblib
 
 git+git://github.com/workforce-data-initiative/skills-ml.git@master
 git+git://github.com/workforce-data-initiative/skills-utils.git@master


### PR DESCRIPTION
The recently added parallel processing has some huge memory usage issues. The approach to fix this is two-pronged:

1. Split up the individual aggregation tasks into different Airflow tasks, with their own outputs, which are then horizontally merged at the end.
2. Pickle each multiprocessing batch output and pass back the filename instead of passing back the entire object.

In the process, I think some of the functionality in the `skills-ml` repository needs updating. Both removing functionality that we are finding to be useless, and adding in some of this functionality. I wanted to make this quick fix change using only the functionality that was available in skills_ml right now, to speed development time.

- Modify soc_aggregate to write each batch to a file instead of sending it to the parent process
- Modify title_aggregate into several tasks, and write each batch to a file instead of sending it to the parent process
- Modify GeoCountOperator to take in map_function as constructor argument to help with serialization
- Modify GeoCountOperator to take in func_name (ie count, common_soc) to output proper filename suffix
- Add MergeOperator to take function name-suffixed files and merge them into a full dataset