### PR TITLE
Upgrade Airflow to v1.8 [Resolves #9]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-airflow[s3]<1.8
+apache-airflow[s3]>=1.8.1
 joblib==0.11
 alembic==0.9.5
 


### PR DESCRIPTION
- Modify requirements to get newest Airflow (1.8.1 has some scheduling improvements over 1.8.0, so let's make sure we get at least that)
- Change API Sync test to match v1.8 API